### PR TITLE
Add functions to query hitcounts

### DIFF
--- a/fireREST/__init__.py
+++ b/fireREST/__init__.py
@@ -886,3 +886,21 @@ class Client(object):
     def update_policy_assignment(self, policy_id: str, data: Dict):
         url = self._url('config', f'/assignment/policyassignments/{policy_id}')
         return self._update(url, data)
+      
+    @utils.minimum_version_required('6.1.0')
+    def get_hitcounts(self, policy_id: str, device_id:str, expanded=True):
+        params = {
+            'expanded': expanded,
+            'filter': "deviceId:{0}".format(device_id)
+        }
+        url = self._url('config', f'/policy/accesspolicies/{policy_id}/operational/hitcounts')
+        return self._get(url, params)
+
+    @utils.minimum_version_required('6.1.0')
+    def get_hitcounts_by_id(self, policy_id: str, device_id:str, rule_id:str, expanded=True):
+        params = {
+            'expanded': expanded,
+            'filter': "deviceId:{0};ids:{1}".format(device_id, rule_id)
+        }
+        url = self._url('config', f'/policy/accesspolicies/{policy_id}/operational/hitcounts')
+        return self._get(url, params)


### PR DESCRIPTION
This is a request to include two new function to query the hitcounts for a policy or rule.

https://developer.cisco.com/site/ftd-api-reference/#!introduction-to-firepower-threat-defense-rest-api/about-the-firepower-threat-defense-rest-api