### PR TITLE
Wrong path for dynamic objects and don't ignore params on update function

### DIFF
--- a/fireREST/fmc/__init__.py
+++ b/fireREST/fmc/__init__.py
@@ -476,7 +476,7 @@ class ChildResource(Resource):
         :rtype: requests.Response
         """
         url = self.url(self.PATH.format(container_uuid=container_uuid, uuid=data['id']))
-        return self.conn.put(url, data, self.IGNORE_FOR_UPDATE)
+        return self.conn.put(url, data, params, self.IGNORE_FOR_UPDATE)
 
     @utils.resolve_by_name
     @utils.minimum_version_required

--- a/fireREST/fmc/object/dynamicobject/mapping/__init__.py
+++ b/fireREST/fmc/object/dynamicobject/mapping/__init__.py
@@ -4,7 +4,7 @@ from fireREST.fmc import ChildResource
 class Mapping(ChildResource):
     CONTAINER_NAME = 'DynamicObject'
     CONTAINER_PATH = '/object/dynamicobjects/{uuid}'
-    PATH = '/object/dynamicobjects/{container_uuid}/overrides/{uuid}'
+    PATH = '/object/dynamicobjects/{container_uuid}/mappings'
     MINIMUM_VERSION_REQUIRED_GET = '7.0.0'
     MINIMUM_VERSION_REQUIRED_UPDATE = '7.0.0'
     MINIMUM_VERSION_REQUIRED_DELETE = '7.0.0'


### PR DESCRIPTION
I have found 2 bug

- Wrong path for dynamic object mappings
- params was ignored on update function