### PR TITLE
ensure version response contains processable information

### DIFF
--- a/fireREST/fmc/__init__.py
+++ b/fireREST/fmc/__init__.py
@@ -259,7 +259,14 @@ class Connection:
         :rtype: version.Version
         """
         url = f'{self.protocol}://{self.hostname}{defaults.API_PLATFORM_URL}/info/serverversion'
-        return version.parse(self._request('get', url).json()['items'][0]['serverVersion'].split(' ')[0])
+        response = self._request('get', url)
+        payload = response.json()
+
+        if 'items' in payload:
+            return version.parse(payload['items'][0]['serverVersion'].split(' ')[0])
+
+        msg = f'Could not determine server version'
+        raise exc.UnprocessableEntityError(msg=msg)
 
     def get_domain_id(self, name: str):
         """helper function to retrieve domain id from list of domains

--- a/test/fmc/test_connection.py
+++ b/test/fmc/test_connection.py
@@ -99,3 +99,10 @@ def test_get_domain_id_with_correct_name(conn):
 def test_get_domain_id_with_incorrect_name(conn):
     with pytest.raises(exc.DomainNotFoundError):
         conn.get_domain_id('NON-EXISTING-DOMAIN')
+
+
+def test_get_version(conn):
+    actual_result = conn.get_version()
+
+    assert actual_result is not None
+


### PR DESCRIPTION
when the server responds with an error or otherwise unprocessable response, the code would result in a KeyError exception. this change inspects the response and throws an explanatory error if it does not meet the expectations.