### PR TITLE
Add CREATE, UPDATE, and DELETE to standardcommunitylist object

### DIFF
--- a/fireREST/fmc/object/standardcommunitylist/__init__.py
+++ b/fireREST/fmc/object/standardcommunitylist/__init__.py
@@ -1,7 +1,10 @@
-from fireREST.defaults import API_RELEASE_660
+from fireREST.defaults import API_RELEASE_660, API_RELEASE_710
 from fireREST.fmc import Resource
 
 
 class StandardCommunityList(Resource):
     PATH = '/object/standardcommunitylists/{uuid}'
+    MINIMUM_VERSION_REQUIRED_CREATE = API_RELEASE_710
     MINIMUM_VERSION_REQUIRED_GET = API_RELEASE_660
+    MINIMUM_VERSION_REQUIRED_UPDATE = API_RELEASE_710
+    MINIMUM_VERSION_REQUIRED_DELETE = API_RELEASE_710


### PR DESCRIPTION
It seems CREATE, UPDATE and DELETE were never added to the standardcommunitylist object, this commit resolves the issue.