### PR TITLE
Added cdFMC login

### DIFF
--- a/fireREST/__init__.py
+++ b/fireREST/__init__.py
@@ -41,8 +41,10 @@ class FMC:
         domain=defaults.API_DEFAULT_DOMAIN,
         timeout=defaults.API_REQUEST_TIMEOUT,
         dry_run=defaults.DRY_RUN,
+        cdo = False,
+		domain_id = None,
     ):
-        self.conn = Connection(hostname, username, password, protocol, verify_cert, domain, timeout, dry_run)
+        self.conn = Connection(hostname, username, password, protocol, verify_cert, domain, timeout, dry_run,cdo,domain_id)
         self.domain = self.conn.domain
         self.version = self.conn.version
         self.assignment = Assignment(self.conn)

--- a/fireREST/__init__.py
+++ b/fireREST/__init__.py
@@ -42,7 +42,7 @@ class FMC:
         timeout=defaults.API_REQUEST_TIMEOUT,
         dry_run=defaults.DRY_RUN,
         cdo = False,
-		domain_id = None,
+        domain_id = None,
     ):
         self.conn = Connection(hostname, username, password, protocol, verify_cert, domain, timeout, dry_run,cdo,domain_id)
         self.domain = self.conn.domain

--- a/fireREST/__init__.py
+++ b/fireREST/__init__.py
@@ -42,7 +42,7 @@ class FMC:
         timeout=defaults.API_REQUEST_TIMEOUT,
         dry_run=defaults.DRY_RUN,
         cdo = False,
-        domain_id = None,
+        domain_id = defaults.API_DEFAULT_DOMAIN_ID,
     ):
         self.conn = Connection(hostname, username, password, protocol, verify_cert, domain, timeout, dry_run,cdo,domain_id)
         self.domain = self.conn.domain

--- a/fireREST/defaults.py
+++ b/fireREST/defaults.py
@@ -44,6 +44,9 @@ API_REQUEST_TIMEOUT = 120
 #: name of fmc default domain for api requests
 API_DEFAULT_DOMAIN = 'Global'
 
+#: default domain ID (in case of CDO)
+API_DEFAULT_DOMAIN_ID = "e276abec-e0f2-11e3-8169-6d9ed49b625f"
+
 #: intial authorization token refresh counter
 API_REFRESH_COUNTER_INIT = 0
 

--- a/fireREST/fmc/__init__.py
+++ b/fireREST/fmc/__init__.py
@@ -56,8 +56,8 @@ class Connection:
         :type timeout: int, optional
         :param dry_run: only log POST,PUT and DELETE api calls
         :type dry_run: bool, optional
-		:param cdo: True when connecting to cdFMC
-		:domain_id: Domain ID of the cdFMC MANDATORY when connecting via CDO
+        :param cdo: True when connecting to cdFMC
+        :domain_id: Domain ID of the cdFMC MANDATORY when connecting via CDO
         """
         if not verify_cert:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)


### PR DESCRIPTION
I have added support for connecting to cdFMC via CDO.

I have applied changes at the parameters to pass to the FMC object and subsequently the Connection class.

New parameters are the following:

domain_id -> defaults to the default Global ID for cdFMC tenants
cdo  -> False  to not modify the behavior for previous uses of the library

Setting "cdo" to True will modify the authentication from HTTPBasic to Bearer Token and will skip the reauthentication.
Furthermore the parameter "domain_id" becomes necessary as the retrieval of domains changes between FMCs and cdFMCs so it needs to be given as input (but most likely the global default will be used most of times)
