### PR TITLE
fix: implement Hitcount.delete() with filter parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,7 @@
 
 ## Fixed
 
+* Fixed `policy.accesspolicy.operational.hitcounts.delete()` not accepting `container_uuid`, `device_id`, or `ids` parameters, making it impossible to reset hitcounts (Issue #102).
 * Fixed `TypeError` in `netmap.host.delete()` and `netmap.vulnerability.delete()` caused by unsupported `url=` keyword argument to `Resource.delete()`.
 * Fixed `cluster.ftddevicecluster.operational.command()` building malformed URLs.
 * Fixed `chassis.operational` methods building malformed URLs.

--- a/fireREST/fmc/policy/accesspolicy/operational/hitcounts/__init__.py
+++ b/fireREST/fmc/policy/accesspolicy/operational/hitcounts/__init__.py
@@ -43,5 +43,6 @@ class Hitcount(ChildResource):
         return super().get(container_uuid, params=params)
 
     @utils.support_params
-    def delete(self):
-        return
+    def delete(self, container_uuid, device_id=None, ids=None, params=None):
+        url = self.url(self.PATH.format(container_uuid=container_uuid, uuid=None))
+        return self.conn.delete(url, params)


### PR DESCRIPTION
## Summary

* `Hitcount.delete()` was a stub returning `None` with no parameters — any call raised `TypeError: Hitcount.delete() got an unexpected keyword argument 'container_uuid'`
* Implemented the method to accept `container_uuid`, `device_id`, and `ids`, matching the OAS3 spec where `filter` is a required query parameter on `DELETE /policy/accesspolicies/{containerUUID}/operational/hitcounts`
* Calls `self.conn.delete(url, params)` directly since `ChildResource.delete()` does not forward `params` to the HTTP layer

Closes #102

## Test plan

- [ ] `fmc.policy.accesspolicy.operational.hitcounts.delete(container_uuid=<acp_id>)` — clears all hitcounts for a policy
- [ ] `fmc.policy.accesspolicy.operational.hitcounts.delete(container_uuid=<acp_id>, device_id=<dev_id>)` — clears hitcounts for a specific device
- [ ] `fmc.policy.accesspolicy.operational.hitcounts.delete(container_uuid=<acp_id>, device_id=<dev_id>, ids=<rule_uuid>)` — clears hitcounts for specific rules only

🤖 Generated with [Claude Code](https://claude.com/claude-code)